### PR TITLE
CHANGELOG for v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format follows **Keep a Changelog** and adheres to **Semantic Versioning**.
+
+---
+
+## [v0.1.0] — Initial MVP Release
+
+### Added
+- Unauthenticated GitHub user reconnaissance
+- Unauthenticated GitLab user reconnaissance
+- Provider-based modular architecture
+- CLI entry point with explicit orchestration layer
+- `--raw` flag to output unprocessed API responses
+- Normalized JSON output via explicit schemas
+- GitHub user schema (`schemas/github_user.json`)
+- GitLab user schema (`schemas/gitlab_user.json`)
+- Core helpers for logging and dependency validation
+
+### Documentation
+- Comprehensive `README.md` with scope, usage, and design principles
+- OSINT flow and mental model documentation
+- API raw → normalized field mappings for GitHub and GitLab
+- Setup and troubleshooting guide
+- Security policy and responsible disclosure guidelines
+
+### Design Notes
+- No authentication support by design
+- Schemas act as authoritative output contracts
+- Clear separation between data retrieval, parsing, and orchestration
+
+### Known Limitations
+- Unauthenticated rate limits apply
+- Limited to public user endpoints
+- No persistence or data enrichment
+
+---
+
+[v0.1.0]: https://github.com/rmottanet/unauthscout/releases/tag/v0.1.0


### PR DESCRIPTION
### Summary
Add the initial `CHANGELOG.md` documenting the first official MVP release
(`v0.1.0`) of UnauthScout.

This PR establishes a clear release history baseline and prepares the repository
for semantic versioning and future iterations.

---

### Changes
- Introduced `CHANGELOG.md`
- Documented features, documentation, and design constraints of the MVP
- Defined known limitations and release scope

---

### Scope
- Documentation only
- No code or behavioral changes

---

### Release Readiness
This PR is intended to be merged **after** the `dev → main` MVP promotion and
**before** tagging `v0.1.0`.
