### PR TITLE
Add unauthenticated repository enumeration support

### DIFF
--- a/bin/unauthscout
+++ b/bin/unauthscout
@@ -14,60 +14,49 @@ main() {
     local raw_mode=false
     local run_github=false
     local run_gitlab=false
+    local fetch_repos=false 
     
     # 1. Dependency Validation (Core)
     check_dependencies
 
     # 2. Flag/argument handling
-    for arg in "$@"; do
-        case "$arg" in
-            --raw)
-                raw_mode=true
-                ;;
-            --github|-gh)
-                run_github=true
-                ;;
-            --gitlab|-gl)
-                run_gitlab=true
-                ;;
-            -h|--help)
-                show_help
-                exit 0
-                ;;
-            -*)
-                die "Unknown option: $arg"
-                ;;
-            *)
-                target="$arg"
-                ;;
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --raw) raw_mode=true; shift ;;
+            --github|-gh) run_github=true; shift ;;
+            --gitlab|-gl) run_gitlab=true; shift ;;
+            --repos|-r) fetch_repos=true; shift ;;
+            -h|--help) show_help; exit 0 ;;
+            -*) die "Unknown option: $1" ;;
+            *) target="$1"; shift ;;
         esac
     done
     
-    if [[ "$target" == "--help" ]] || [[ "$target" == "-h" ]] || is_empty "$target"; then
-        show_help
-        exit 0
-    fi
-    
-    # If NO platform was specifically selected, activate BOTH.
+    # 3. Defaults
+    if [[ -z "$target" ]]; then show_help; exit 0; fi
     if [[ "$run_github" == false && "$run_gitlab" == false ]]; then
-        run_github=true
-        run_gitlab=true
+        run_github=true; run_gitlab=true
     fi
-    
-    # 3. Beginning of Recognition
+
     log_info "Starting scout on target: ${CLR_SUCCESS}${target}${CLR_RESET}"
     echo "------------------------------------------------------------"
 
-    # --- Execução GitLab ---
+    # --- Fluxo GitLab ---
     if [[ "$run_gitlab" == true ]]; then
         log_info "Searching on GitLab..."
-        user_gitlab="$(get_gitlab_user_raw "$target")"
         
-        if [[ -n "$user_gitlab" ]]; then
-            if [[ "$raw_mode" == true ]]; then
-                echo "$user_gitlab"
-            else
-                echo "$user_gitlab" | parse_gitlab_user || log_error "Failed to parse GitLab data"
+        # 1. Profile
+        local user_data
+        user_data=$(get_gitlab_user_raw "$target")
+        if [[ -n "$user_data" && "$user_data" != "[]" ]]; then
+            [[ "$raw_mode" == true ]] && echo "$user_data" || echo "$user_data" | parse_gitlab_user
+            
+            # 2. Repos (Condicional)
+            if [[ "$fetch_repos" == true ]]; then
+                log_info "Fetching GitLab repositories..."
+                local repo_data
+                repo_data=$(get_gitlab_repos_raw "$target")
+                [[ "$raw_mode" == true ]] && echo "$repo_data" || echo "$repo_data" | parse_gitlab_repos
             fi
         else
             log_warn "User not found on GitLab"
@@ -75,16 +64,22 @@ main() {
         echo "------------------------------------------------------------"
     fi
 
-    # --- Execução GitHub ---
+    # --- Fluxo GitHub ---
     if [[ "$run_github" == true ]]; then
         log_info "Searching on GitHub..."
-        user_github="$(get_github_user_raw "$target")"
         
-        if [[ -n "$user_github" ]]; then
-            if [[ "$raw_mode" == true ]]; then
-                echo "$user_github"
-            else
-                echo "$user_github" | parse_github_user || log_error "Failed to parse GitHub data"
+        # 1. Profile
+        local gh_user
+        gh_user=$(get_github_user_raw "$target")
+        if [[ -n "$gh_user" ]]; then
+            [[ "$raw_mode" == true ]] && echo "$gh_user" || echo "$gh_user" | parse_github_user
+            
+            # 2. Repos (Condicional)
+            if [[ "$fetch_repos" == true ]]; then
+                log_info "Fetching GitHub repositories..."
+                local gh_repos
+                gh_repos=$(get_github_repos_raw "$target")
+                [[ "$raw_mode" == true ]] && echo "$gh_repos" || echo "$gh_repos" | parse_github_repos
             fi
         else
             log_warn "User not found on GitHub"
@@ -93,8 +88,6 @@ main() {
     fi
 
     log_success "Scout finished for $target"
-    
 }
 
-# Start the script by passing all the arguments.
 main "$@"

--- a/docs/en/content/Home.md
+++ b/docs/en/content/Home.md
@@ -19,14 +19,23 @@ This wiki follows **DRY (Don't Repeat Yourself)** principles:
 
 ## 📢 What's New
 
-### Latest Release: [v0.1.0](https://github.com/rmottanet/unauthscout/releases/tag/v0.1.0)
-- GitLab user enumeration
-- Normalized JSON output via schemas
-- Basic CLI interface
-- Provider-based architecture foundation
+### Versão mais recente: [v0.2.0](https://github.com/rmottanet/unauthscout/releases/tag/v0.2.0)
+- **Enumeração de repositórios** – Listagem de repositórios de usuários para GitHub e GitLab
+- Documentação expandida de mapeamento de campos da API
+- Atualizações de documentação multilíngue (EN/PT)
+- CLI aprimorada com suporte à flag `--repos`
 
-### Currently in Development (v0.2.0)
-- ** Repository enumeration** - User repository listing for both providers
+### Versão anterior: [v0.1.0](https://github.com/rmottanet/unauthscout/releases/tag/v0.1.0)
+- Enumeração de usuários do GitLab
+- Saída JSON normalizada via esquemas
+- Interface CLI básica
+- Base para arquitetura baseada em provedores
+
+### Atualmente em desenvolvimento (v0.3.0)
+- **Normalização e inteligência resumida** – Transformação de dados brutos do provedor em insights de reconhecimento unificados
+- Comparação de dados aprimorada entre plataformas
+- Resumo inteligente de pegadas de usuários e repositórios
+- Base para correlação e relatórios entre fornecedores
 
 
 ## 📌 Important Notes

--- a/docs/en/content/_Sidebar.md
+++ b/docs/en/content/_Sidebar.md
@@ -1,14 +1,16 @@
 # [UnauthScout Wiki](./Home)
 
 ## 🚀 Getting Started
-[Setup & Installation](./setup) - Quick install guide and first configuration
+[Setup & Usage](./setup) - Quick install guide and first configuration
 
 ## 🧩 Core Concepts
 [OSINT Workflow](./osint-flow) - Ethical reconnaissance methodology and best practices
 
 ## 📊 API Documentation
-[GitHub API Map](./github-user-map) - Complete field mapping for GitHub user data  
-[GitLab API Map](./gitlab-user-map) - Complete field mapping for GitLab user data
+- [GitHub API Repo Map](./github-repo-map) - Complete field mapping for GitHub repo data  
+- [GitHub API User Map](./github-user-map) - Complete field mapping for GitHub user data
+- [GitLab API Repo Map](./gitlab-repo-map) - Complete field mapping for GitLab repo data
+- [GitLab API User Map](./gitlab-user-map) - Complete field mapping for GitLab user data
 
 ---
 

--- a/docs/en/content/api_maps/github-repo-map.md
+++ b/docs/en/content/api_maps/github-repo-map.md
@@ -1,0 +1,117 @@
+# GitHub Repository API Field Mapping
+
+This document describes how fields from the **unauthenticated GitHub Repositories API**
+response are mapped and normalized by UnauthScout.
+
+It serves as a reference for:
+- Understanding which raw fields are used
+- Validating schema alignment
+- Auditing normalization decisions
+
+## Endpoint
+
+```
+
+GET [https://api.github.com/users/{username}/repos](https://api.github.com/users/{username}/repos)
+
+```
+
+- Authentication: ❌ Not required
+- Scope: Public repositories only
+- Pagination: `per_page=100` (maximum allowed)
+
+## Raw Response Overview
+
+The GitHub Repositories API returns an **array of repository objects**, each containing
+extensive metadata, internal API URLs, feature flags, and configuration details.
+
+UnauthScout intentionally selects a **minimal subset** of stable, OSINT-relevant
+repository metadata suitable for cross-provider normalization.
+
+## Field Mapping
+
+| Raw Field              | Normalized Field | Included | Notes |
+|------------------------|------------------|----------|-------|
+| `id`                   | `id`             | ✅       | Stable unique repository identifier |
+| `name`                 | `name`           | ✅       | Repository name |
+| `full_name`            | `full_name`      | ✅       | Owner/repository (globally unique) |
+| `description`          | `description`    | ✅       | Nullable, useful for context |
+| `html_url`             | `url`            | ✅       | Public repository URL |
+| `stargazers_count`     | `stars`          | ✅       | Popularity signal |
+| `forks_count`          | `forks`          | ✅       | Activity and reuse signal |
+| `language`             | `language`       | ✅       | Primary language (nullable) |
+| `private`              | —                | ❌       | Always false for public enumeration |
+| `owner`                | —                | ❌       | Redundant (implicit via username) |
+| `topics`               | —                | ❌       | Requires preview headers |
+| `license`              | —                | ❌       | Often null / inconsistent |
+| `created_at`           | —                | ❌       | Not required for MVP |
+| `updated_at`           | —                | ❌       | Highly volatile |
+| `pushed_at`            | —                | ❌       | Activity noise |
+| `size`                 | —                | ❌       | Low OSINT value |
+| `default_branch`       | —                | ❌       | Operational detail |
+| `clone_url`            | —                | ❌       | Non-OSINT |
+| `ssh_url`              | —                | ❌       | Non-OSINT |
+| `fork`                 | —                | ❌       | Context-specific, excluded for MVP |
+| `archived`             | —                | ❌       | Edge-case, low signal |
+| `disabled`             | —                | ❌       | Rare, non-actionable |
+| `permissions`          | —                | ❌       | Auth-dependent |
+| `hooks_url`            | —                | ❌       | Internal API URL |
+| `issues_url`           | —                | ❌       | Internal API URL |
+
+## Normalization Logic
+
+The current normalization is implemented as:
+
+```bash
+parse_github_repos() {
+    jq '.[] | {
+        id,
+        name: .name,
+        full_name: .full_name,
+        description,
+        url: .html_url,
+        stars: .stargazers_count,
+        forks: .forks_count,
+        language
+    }'
+}
+````
+
+Each repository is emitted as a **single normalized object**.
+
+## Output Contract
+
+The normalized output conforms to:
+
+```
+schemas/github_user_repos.json
+```
+
+This schema is the **authoritative definition** of GitHub repository output
+within UnauthScout.
+
+## Rationale
+
+Field inclusion follows these principles:
+
+* Fields must be consistently present
+* Fields must be OSINT-relevant
+* Fields must support cross-provider parity
+* Fields must not require authentication
+* Fields must be automatable and stable
+
+All other fields are intentionally excluded to reduce noise, avoid API drift,
+and preserve long-term contract stability.
+
+## Notes on Evolution
+
+* Additional metadata (e.g. license, topics) may be added in future versions
+* Repository activity timelines are intentionally excluded from MVP scope
+* Authenticated-only fields will require a separate contract and schema
+* Breaking changes will be documented explicitly
+
+## Summary
+
+This mapping ensures that UnauthScout emits a **clean, minimal, and predictable**
+representation of public GitHub repositories, suitable for OSINT workflows,
+automation pipelines, and future provider expansion.

--- a/docs/en/content/api_maps/github-user-map.md
+++ b/docs/en/content/api_maps/github-user-map.md
@@ -14,7 +14,7 @@ It serves as a reference for:
 
 GET [https://api.github.com/users/{username}](https://api.github.com/users/{username})
 
-````
+```
 
 - Authentication: ❌ Not required
 - Scope: Public user data only

--- a/docs/en/content/api_maps/gitlab-repo-map.md
+++ b/docs/en/content/api_maps/gitlab-repo-map.md
@@ -1,0 +1,112 @@
+# GitLab Project API Field Mapping
+
+This document describes how fields from the **unauthenticated GitLab Projects API**
+response are mapped and normalized by UnauthScout.
+
+It serves as a reference for:
+- Understanding which raw fields are used
+- Validating schema alignment
+- Auditing normalization decisions
+
+## Endpoint
+
+```
+
+GET [https://gitlab.com/api/v4/users/{username}/projects](https://gitlab.com/api/v4/users/{username}/projects)
+
+```
+
+- Authentication: ❌ Not required
+- Scope: Public projects only
+- Filters: `visibility=public`
+- Pagination: `per_page=100`
+
+## Raw Response Overview
+
+The GitLab Projects API returns an **array of project objects**, each containing
+metadata, internal URLs, permissions, and platform-specific configuration fields.
+
+UnauthScout intentionally selects a **minimal subset** of stable, OSINT-relevant
+project metadata suitable for cross-provider normalization.
+
+## Field Mapping
+
+| Raw Field                | Normalized Field | Included | Notes |
+|--------------------------|------------------|----------|-------|
+| `id`                     | `id`             | ✅       | Stable unique project identifier |
+| `name`                   | `name`           | ✅       | Project name |
+| `path_with_namespace`    | `path`           | ✅       | Fully qualified project path |
+| `description`            | `description`    | ✅       | Nullable, contextual |
+| `web_url`                | `url`            | ✅       | Public project URL |
+| `star_count`             | `stars`          | ✅       | Popularity signal |
+| `forks_count`            | `forks`          | ✅       | Reuse and activity signal |
+| `visibility`             | —                | ❌       | Filtered at request time |
+| `namespace`              | —                | ❌       | Redundant with path |
+| `owner`                  | —                | ❌       | Not always present |
+| `default_branch`         | —                | ❌       | Operational detail |
+| `created_at`             | —                | ❌       | Not required for MVP |
+| `last_activity_at`       | —                | ❌       | Volatile |
+| `archived`               | —                | ❌       | Edge-case, low signal |
+| `topics`                 | —                | ❌       | Not consistently populated |
+| `readme_url`             | —                | ❌       | Secondary resource |
+| `http_url_to_repo`       | —                | ❌       | Non-OSINT |
+| `ssh_url_to_repo`        | —                | ❌       | Non-OSINT |
+| `permissions`            | —                | ❌       | Auth-dependent |
+| `_links`                 | —                | ❌       | Internal API URLs |
+
+## Normalization Logic
+
+The current normalization is implemented as:
+
+```bash
+parse_gitlab_repos() {
+    jq '.[] | {
+        id,
+        name: .name,
+        path: .path_with_namespace,
+        description,
+        url: .web_url,
+        stars: .star_count,
+        forks: .forks_count
+    }'
+}
+````
+
+Each project is emitted as a **single normalized object**.
+
+## Output Contract
+
+The normalized output conforms to:
+
+```
+schemas/gitlab_user_repos.json
+```
+
+This schema is the **authoritative definition** of GitLab project output
+within UnauthScout.
+
+## Rationale
+
+Field inclusion follows these principles:
+
+* Fields must be consistently present
+* Fields must be OSINT-relevant
+* Fields must support cross-provider parity
+* Fields must not require authentication
+* Fields must be stable across GitLab versions
+
+All other fields are intentionally excluded to reduce noise, avoid platform
+specific coupling, and preserve long-term contract stability.
+
+## Notes on Evolution
+
+* Additional metadata (e.g. topics, license) may be added in future versions
+* Group-owned projects may receive extended handling in future releases
+* Authenticated-only fields will require a separate contract and schema
+* Breaking changes will be documented explicitly
+
+## Summary
+
+This mapping ensures that UnauthScout emits a **clean, minimal, and predictable**
+representation of public GitLab projects, suitable for OSINT workflows,
+automation pipelines, and provider-agnostic analysis.

--- a/docs/en/content/api_maps/gitlab-user-map.md
+++ b/docs/en/content/api_maps/gitlab-user-map.md
@@ -11,8 +11,10 @@ It provides a clear reference for:
 ## Endpoint
 
 ```
+
 GET [https://gitlab.com/api/v4/users?username={username}](https://gitlab.com/api/v4/users?username={username})
-````
+
+```
 
 - Authentication: ❌ Not required
 - Scope: Public user search results

--- a/docs/en/content/osint-flow.md
+++ b/docs/en/content/osint-flow.md
@@ -27,7 +27,6 @@ The goal is not data exhaustion, but **signal extraction**:
 ## High-Level Flow
 
 ```txt
-
 Target
 ↓
 Provider Selection
@@ -39,11 +38,9 @@ Raw Response
 Normalization (Schema)
 ↓
 Structured Output
-
-```
+````
 
 Each step has a **single responsibility** and a clearly defined boundary.
-
 
 ## Step-by-Step Breakdown
 
@@ -52,112 +49,192 @@ Each step has a **single responsibility** and a clearly defined boundary.
 The user provides a target identifier (e.g. username).
 
 UnauthScout does not:
-- Guess identities
-- Correlate across platforms
-- Perform enrichment at this stage
+
+* Guess identities
+* Correlate across platforms
+* Perform enrichment at this stage
 
 The target is treated as an opaque identifier passed to the provider.
-
 
 ### 2. Provider Selection
 
 The CLI determines which provider module to invoke (e.g. GitHub, GitLab).
 
 Responsibilities:
-- Routing
-- Flag handling (`--raw`, future output modes)
-- Error propagation
+
+* Routing
+* Flag handling (`--raw`, `--repos`)
+* Error propagation
 
 The entry point **does not implement reconnaissance logic**.
-
 
 ### 3. Unauthenticated API Request
 
 Each provider module performs:
-- A direct request to the public API
-- Without authentication
-- Without retries or rate-limit evasion
+
+* A direct request to the public API
+* Without authentication
+* Without retries or rate-limit evasion
 
 This guarantees:
-- Ethical use
-- Reproducibility
-- Clear trust boundaries
 
+* Ethical use
+* Reproducibility
+* Clear trust boundaries
 
 ### 4. Raw Response Handling
 
 The raw API response represents **ground truth**.
 
 UnauthScout supports a `--raw` mode to:
-- Inspect available fields
-- Validate assumptions
-- Aid schema evolution
+
+* Inspect available fields
+* Validate assumptions
+* Aid schema evolution
 
 Raw output is intended for **analysis and development**, not automation.
-
 
 ### 5. Normalization
 
 Normalization transforms raw responses into a **stable, minimal contract**.
 
 Principles:
-- Only include fields that are consistently available
-- Avoid volatile or provider-internal fields
-- Prefer identifiers and public-facing attributes
+
+* Only include fields that are consistently available
+* Avoid volatile or provider-internal fields
+* Prefer identifiers and public-facing attributes
 
 Normalization is implemented via dedicated parser functions and documented
 schemas under `schemas/`.
 
-
 ### 6. Structured Output
 
 The final output:
-- Is deterministic
-- Conforms to a documented schema
-- Is suitable for scripting, storage, and downstream tooling
+
+* Is deterministic
+* Conforms to a documented schema
+* Is suitable for scripting, storage, and downstream tooling
 
 This output is the **primary interface** of UnauthScout.
 
+## Repository / Project Enumeration
+
+Repository (GitHub) and project (GitLab) enumeration is a **conditional extension**
+of the core OSINT flow, activated explicitly via the `--repos` flag.
+
+This phase follows the **same mental model** as profile reconnaissance and does
+not introduce a new class of behavior.
+
+### Trigger Condition
+
+Enumeration occurs only when:
+
+* A valid user/profile is observed on a provider
+* The user explicitly requests repository listing (`--repos`)
+
+This avoids:
+
+* Unnecessary API calls
+* Accidental rate-limit exhaustion
+* Implicit scope expansion
+
+### Enumeration Flow
+
+```txt
+Normalized User Identified
+↓
+Public Repository / Project Request
+↓
+Raw Repository Response
+↓
+Repository Normalization (Schema)
+↓
+Structured Repository Output
+```
+
+Each repository/project is treated as an **independent observable entity**.
+
+### Enumeration Principles
+
+* Only public repositories/projects are queried
+* Enumeration is scoped per provider
+* No cross-provider correlation is performed
+* No recursive traversal (issues, commits, contributors)
+
+The goal is **surface mapping**, not deep inspection.
+
+### Normalization and Contracts
+
+Repositories and projects are normalized into provider-specific but semantically
+aligned schemas:
+
+* `schemas/github_user_repos.json`
+* `schemas/gitlab_user_repos.json`
+
+Field selection prioritizes:
+
+* Identifiers
+* Public URLs
+* Popularity and activity signals
+* Cross-provider comparability
+
+Detailed field mappings are documented under:
+
+* `docs/api_maps/github_repo_map.md`
+* `docs/api_maps/gitlab_repo_map.md`
+
+### Output Characteristics
+
+Repository enumeration output:
+
+* Is emitted as a stream of normalized objects
+* Preserves ordering as returned by the provider
+* Can be consumed incrementally by downstream tooling
+
+Raw output (`--raw`) remains available for inspection and schema evolution.
 
 ## Why Schemas Matter
 
 Schemas serve as:
-- A contract between providers and consumers
-- Documentation of observable behavior
-- A guardrail against silent breaking changes
+
+* A contract between providers and consumers
+* Documentation of observable behavior
+* A guardrail against silent breaking changes
 
 Schemas are authoritative.
 Code adapts to schemas, not the other way around.
 
-
 ## What This Flow Does Not Cover
 
 UnauthScout intentionally excludes:
-- Authenticated reconnaissance
-- Rate-limit handling
-- Cross-platform correlation
-- Behavioral analysis
-- Historical tracking
+
+* Authenticated reconnaissance
+* Rate-limit handling
+* Cross-platform correlation
+* Behavioral analysis
+* Historical tracking
+* Deep repository inspection (issues, commits, CI)
 
 These concerns belong to higher-level systems built *on top of* this tool.
-
 
 ## Evolution Strategy
 
 Future extensions follow the same flow:
-- New provider → new module
-- New endpoint → new schema
-- New output format → CLI-level concern
 
-The OSINT flow remains unchanged.
+* New provider → new module
+* New endpoint → new schema
+* New output format → CLI-level concern
 
+The OSINT flow remains stable.
 
 ## Summary
 
 UnauthScout is designed as a **primitive**:
-- Small
-- Predictable
-- Composable
+
+* Small
+* Predictable
+* Composable
 
 Its value lies not in the volume of data collected, but in the **clarity and
 reliability** of the data it emits.
+

--- a/docs/en/content/setup.md
+++ b/docs/en/content/setup.md
@@ -53,6 +53,46 @@ Expected behavior:
 * No authentication prompts
 * No stack traces or shell errors
 
+## Repository / Project Enumeration
+
+UnauthScout can optionally enumerate **public repositories/projects** associated
+with a user via the `--repos` flag.
+
+This feature is **explicitly opt-in** and scoped per provider.
+
+### Enumerate repositories on both providers
+
+```bash
+unauthscout torvalds --repos
+```
+
+### Enumerate GitHub repositories only
+
+```bash
+unauthscout torvalds --github --repos
+```
+
+### Enumerate GitLab projects only
+
+```bash
+unauthscout dzaporozhets --gitlab --repos
+```
+
+### Combine with raw mode
+
+Raw mode can be used to inspect the original API responses:
+
+```bash
+unauthscout torvalds --repos --raw
+unauthscout torvalds --github --repos --raw
+```
+
+Raw output is useful for:
+
+* Inspecting newly exposed fields
+* Validating API behavior
+* Supporting schema evolution
+
 ## Common Errors and Troubleshooting
 
 ### Missing dependency
@@ -68,6 +108,7 @@ Expected behavior:
 * One or more required tools are not installed or not in PATH.
 
 **Resolution**
+
 Install the missing dependency, for example:
 
 ```bash
@@ -88,17 +129,23 @@ or
 [ERROR] Failed to fetch GitLab user data
 ```
 
+or during repository enumeration:
+
+```
+[ERROR] Failed to fetch repository data
+```
+
 **Possible causes**
 
 * Network connectivity issues
 * Temporary API outage
-* Rate limiting by the provider
+* Provider rate limiting
 
 **Resolution**
 
 * Verify network access
-* Retry the request
-* Use `--raw` to inspect partial responses if available
+* Retry the request after a delay
+* Use `--raw` to inspect partial responses
 
 ### Parsing failure
 
@@ -117,19 +164,20 @@ or
 **Resolution**
 
 * Re-run the command with `--raw`
-* Compare raw output with the documented API mapping
-* Validate schema alignment
+* Compare raw output with the documented API mappings
+* Validate schema alignment under `schemas/`
 
 ### No results returned (GitLab)
 
 **Behavior**
 
-* Empty output or parsing error
+* Empty output or parsing error during profile or project lookup
 
 **Cause**
 
 * The GitLab `/users?username=` endpoint returns an empty array
 * Username does not exist or is ambiguous
+* User has no public projects
 
 **Resolution**
 
@@ -142,7 +190,8 @@ UnauthScout provides a `--raw` flag to bypass normalization:
 
 ```bash
 unauthscout <username> --raw
-unauthscout <username> --raw -gh
+unauthscout <username> --github --raw
+unauthscout <username> --repos --raw
 ```
 
 Use raw mode to:
@@ -169,6 +218,7 @@ UnauthScout does not attempt to bypass rate limits.
 For sustained usage, consider:
 
 * Spacing requests
+* Limiting provider scope (`--github` / `--gitlab`)
 * Adding authenticated support in a future version
 
 ## Summary
@@ -181,3 +231,4 @@ If something breaks:
 2. Re-run with `--raw`
 3. Compare raw output against the API mapping docs
 4. Update schemas and parsers accordingly
+

--- a/docs/pt/content/CONTRIBUTING.md
+++ b/docs/pt/content/CONTRIBUTING.md
@@ -1,0 +1,339 @@
+# Contribuindo para o UnauthScout
+
+Obrigado pelo seu interesse em contribuir com o UnauthScout! Este documento descreve os padrões do projeto, processo de desenvolvimento e como você pode ajudar.
+
+---
+
+## 🎯 Visão Geral
+
+UnauthScout segue princípios de design específicos:
+- **Não autenticado por padrão** - Sem tokens, sem credenciais
+- **Contratos explícitos** - Schemas JSON como fonte da verdade
+- **Arquitetura baseada em providers** - Extensível, mas consistente
+- **CLI-first** - Interface de linha de comando como prioridade
+
+---
+
+## 📋 Antes de Começar
+
+### Pré-requisitos
+- Bash (POSIX-compatible)
+- `curl` e `jq` instalados
+- Git básico (clone, branch, PR)
+- Entendimento de APIs REST
+
+### Ambiente de Desenvolvimento
+```bash
+# 1. Fork e clone
+git clone https://github.com/SEU_USERNAME/unauthscout.git
+cd unauthscout
+
+# 2. Teste a instalação local
+chmod +x bin/unauthscout
+./bin/unauthscout --version
+
+# 3. Execute os testes (se houver)
+./run-tests.sh
+```
+
+---
+
+## 🏗 Arquitetura do Projeto
+
+```
+unauthscout/
+├── bin/
+│   └── unauthscout          # Ponto de entrada CLI
+├── lib/
+│   ├── github_api.sh        # Integração com GitHub API
+│   ├── gitlab_api.sh        # Integração com GitLab API
+│   └── common/              # Lógica compartilhada
+├── schemas/                 # Contratos de dados (JSON Schema)
+├── docs/                    # Documentação técnica
+└── tests/                   # Testes automatizados
+```
+
+### Princípios de Design
+1. **Separação de responsabilidades**: Cada provider em seu próprio arquivo
+2. **Schemas como contratos**: Validação e documentação integradas
+3. **Fail fast**: Erros claros e específicos
+4. **Output consistente**: JSON normalizado entre providers
+
+---
+
+## 🔧 Processo de Desenvolvimento
+
+### 1. Fluxo de Trabalho
+```mermaid
+graph LR
+    A[Issue/Feature] --> B[Fork & Branch]
+    B --> C[Desenvolvimento]
+    C --> D[Testes]
+    D --> E[Pull Request]
+    E --> F[Review]
+    F --> G[Merge]
+```
+
+### 2. Branch Naming Convention
+```
+feature/  - Novas funcionalidades     Ex: feature/github-repos
+fix/      - Correções de bugs         Ex: fix/curl-timeout
+docs/     - Documentação              Ex: docs/api-examples
+refactor/ - Refatoração               Ex: refactor/output-formatting
+```
+
+### 3. Commits Semânticos
+```bash
+# Formato: tipo(escopo): descrição
+
+feat(github): add repository enumeration
+fix(core): handle API rate limiting
+docs(readme): update installation instructions
+refactor(gitlab): simplify user parsing
+test: add integration tests for providers
+chore: update dependencies in bin/ script
+```
+
+**Tipos válidos**: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+
+---
+
+## 🧪 Padrões de Código
+
+### Shell Script Guidelines
+```bash
+#!/usr/bin/env bash
+# Nome do arquivo: snake_case.sh
+
+# Variáveis: UPPERCASE com underscores
+GITHUB_API_URL="https://api.github.com"
+MAX_RETRIES=3
+
+# Funções: snake_case com descrição
+fetch_user_data() {
+    local username="$1"  # Sempre declarar variáveis locais
+    local timeout="${2:-10}"  # Valores padrão
+    
+    # Validação early return
+    [[ -z "$username" ]] && return 1
+    
+    # Código principal
+    curl -sf --max-time "$timeout" \
+        "${GITHUB_API_URL}/users/${username}"
+}
+
+# Tratamento de erros consistente
+die() {
+    echo "Error: $1" >&2
+    exit 1
+}
+```
+
+### Regras Específicas
+1. **Shebang**: Sempre `#!/usr/bin/env bash`
+2. **Modo estrito**: `set -euo pipefail` em scripts complexos
+3. **Variáveis**: Declarar antes de usar, sempre entre aspas
+4. **Funções**: Documentar com comentário acima da função
+5. **Exit codes**: 0 para sucesso, 1+ para erros específicos
+
+---
+
+## 📝 Documentação
+
+### 1. Inline Comments
+```bash
+# BOM: Explica o "porquê", não o "o quê"
+# Cache por 60 segundos para evitar rate limiting
+cache_ttl=60
+
+# RUIM: Óbvio
+# Define cache_ttl como 60
+cache_ttl=60
+```
+
+### 2. README vs Wiki
+- **README.md**: Visão geral, instalação rápida, exemplos básicos
+- **Wiki**: Documentação completa, tutoriais, referência de API
+
+### 3. Schemas como Documentação
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GitHub User",
+  "description": "Normalized GitHub user profile",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "description": "GitHub's internal user ID"
+    }
+  }
+}
+```
+
+---
+
+## 🐛 Reportando Issues
+
+### Template de Bug Report
+```markdown
+## Descrição do Bug
+[Descrição clara e concisa]
+
+## Passos para Reproduzir
+1. Comando executado: `unauthscout ...`
+2. Erro observado: [mensagem de erro]
+3. Comportamento esperado: [o que deveria acontecer]
+
+## Ambiente
+- OS: [ex: Ubuntu 22.04]
+- Bash version: `bash --version`
+- curl version: `curl --version`
+- jq version: `jq --version`
+
+## Logs Relevantes
+[Saída do comando com --verbose se aplicável]
+```
+
+### Template de Feature Request
+```markdown
+## Problema/Necessidade
+[O que você está tentando resolver]
+
+## Solução Proposta
+[Descrição da funcionalidade]
+
+## Alternativas Consideradas
+[Outras abordagens possíveis]
+
+## Impacto Esperado
+[Quem se beneficiaria e como]
+```
+
+---
+
+## 🔄 Pull Request Process
+
+### 1. Checklist do PR
+- [ ] Código segue padrões do projeto
+- [ ] Testes adicionados/atualizados (se aplicável)
+- [ ] Documentação atualizada
+- [ ] Schema atualizado (se mudar output)
+- [ ] Commits semânticos e bem descritos
+
+### 2. Template do PR
+```markdown
+## Mudanças
+[Lista das principais alterações]
+
+## Tipo de Mudança
+- [ ] Bug fix
+- [ ] Nova feature
+- [ ] Breaking change
+- [ ] Documentação
+
+## Testes
+[Como você testou as mudanças]
+
+## Screenshots/Output
+[Saída relevante do CLI]
+
+## Issues Relacionadas
+Fixes #123
+```
+
+### 3. Review Guidelines
+- **Reviewers**: Focar em lógica, segurança e consistência
+- **Authors**: Responder a todos os comentários do review
+- **Todos**: Manter discussão técnica e respeitosa
+
+---
+
+## 🏷 Versionamento
+
+### Semantic Versioning
+```
+MAJOR.MINOR.PATCH
+1.0.0
+
+MAJOR - Breaking changes em schemas ou CLI
+MINOR - Novas features sem breaking changes
+PATCH - Bug fixes e melhorias menores
+```
+
+### Processo de Release
+1. Issues agrupadas em milestones
+2. Feature freeze antes do release
+3. Tagging com versão semântica
+4. CHANGELOG.md atualizado
+
+---
+
+## 🛡 Segurança
+
+### Reporting Security Issues
+**NÃO abra issues públicas para vulnerabilidades!**
+
+Email: [seu-email@domain.com]  
+Assunto: "Security Vulnerability in UnauthScout"
+
+Inclua:
+- Descrição detalhada
+- Passos para reproduzir
+- Impacto potencial
+- Sugestões de correção
+
+---
+
+## ❓ Dúvidas Frequentes
+
+### "Onde começo a contribuir?"
+1. Veja issues com label `good-first-issue`
+2. Check `help-wanted` para tarefas acessíveis
+3. Melhore documentação existente
+
+### "Preciso conhecer todas as APIs?"
+Não! Foque em um provider por vez. Cada um tem seu arquivo.
+
+### "Como testar sem fazer spam nas APIs?"
+Use mocks ou dados de exemplo. Evite chamadas reais em loops.
+
+---
+
+## 📞 Suporte
+
+- **Discussions**: Para dúvidas e ideias
+- **Issues**: Para bugs e feature requests
+- **Wiki**: Para documentação completa
+
+---
+
+## 🙏 Agradecimentos
+
+Obrigado por contribuir para ferramentas de código aberto! Cada PR, issue reportada ou estrela no repositório ajuda a comunidade.
+
+---
+
+*Este documento é vivo e evolui com o projeto. Sugestões de melhoria são bem-vindas!*
+```
+
+## 📁 Arquivos Relacionados a Criar:
+
+```
+.github/
+├── ISSUE_TEMPLATE/
+│   ├── bug_report.md
+│   └── feature_request.md
+├── PULL_REQUEST_TEMPLATE.md
+└── CODE_OF_CONDUCT.md
+```
+
+## 🎯 Pontos Chave Deste CONTRIBUTING.md:
+
+1. **Específico para UnauthScout** - Não genérico
+2. **Inclui padrões técnicos** - Shell script guidelines
+3. **Processo claro** - Do fork ao merge
+4. **Focado em qualidade** - Schemas, testes, documentação
+5. **Amigável para novos contribuidores** - Começo fácil
+
+Este documento estabelece expectativas claras enquanto mantém a porta aberta para contribuições da comunidade! 🚀

--- a/docs/pt/content/_sidebar.md
+++ b/docs/pt/content/_sidebar.md
@@ -12,8 +12,10 @@
 
 <h3>📊 API Documentation</h3>
 <ul>
-    <li>[GitHub API Map](api_maps/github-user-map) - Mapeamento completo de campos para dados de usuários do GitHub</li>
-    <li>[GitLab API Map](api_maps/gitlab-user-map) - Mapeamento completo dos campos para dados de usuários do GitLab</li>
+    <li>[GitHub API Repo Map](api_maps/github-repo-map) - Mapeamento completo de campos para dados de usuários do GitHub</li>
+    <li>[GitHub API User Map](api_maps/github-user-map) - Mapeamento completo dos campos para dados de usuários do GitLab</li>
+    <li>[GitLab API Repo Map](api_maps/gitlab-repo-map) - Mapeamento completo dos campos para dados de usuários do GitLab</li>
+    <li>[GitLab API User Map](api_maps/gitlab-user-map) - Mapeamento completo dos campos para dados de usuários do GitLab</li>
 </ul>
 
 ---

--- a/docs/pt/content/api_maps/github-repo-map.md
+++ b/docs/pt/content/api_maps/github-repo-map.md
@@ -1,0 +1,116 @@
+# Mapeamento de Campos da API de Repositórios do GitHub
+
+Este documento descreve como os campos das **respostas da API de Repositórios do GitHub não autenticadas**
+são mapeados e normalizados pelo UnauthScout.
+
+Ele serve como referência para:
+- Entender quais campos brutos são usados
+- Validar o alinhamento do esquema
+- Auditar as decisões de normalização
+
+## Endpoint
+
+```
+
+GET [https://api.github.com/users/{username}/repos](https://api.github.com/users/{username}/repos)
+
+```
+
+- Autenticação: ❌ Não obrigatória
+- Escopo: Somente repositórios públicos
+- Paginação: `per_page=100` (máximo permitido)
+
+## Visão Geral da Resposta Bruta
+
+A API de Repositórios do GitHub retorna um **array de objetos de repositório**, cada um contendo
+metadados extensos, URLs internas da API, sinalizadores de recursos e detalhes de configuração.
+
+O UnauthScout seleciona intencionalmente um **subconjunto mínimo** de metadados de repositório estáveis ​​e relevantes para OSINT,
+adequados para normalização entre provedores.
+
+## Mapeamento de Campos
+
+| Raw Field              | Normalized Field | Included | Notes |
+|------------------------|------------------|----------|-------|
+| `id`                   | `id`             | ✅       | Stable unique repository identifier |
+| `name`                 | `name`           | ✅       | Repository name |
+| `full_name`            | `full_name`      | ✅       | Owner/repository (globally unique) |
+| `description`          | `description`    | ✅       | Nullable, useful for context |
+| `html_url`             | `url`            | ✅       | Public repository URL |
+| `stargazers_count`     | `stars`          | ✅       | Popularity signal |
+| `forks_count`          | `forks`          | ✅       | Activity and reuse signal |
+| `language`             | `language`       | ✅       | Primary language (nullable) |
+| `private`              | —                | ❌       | Always false for public enumeration |
+| `owner`                | —                | ❌       | Redundant (implicit via username) |
+| `topics`               | —                | ❌       | Requires preview headers |
+| `license`              | —                | ❌       | Often null / inconsistent |
+| `created_at`           | —                | ❌       | Not required for MVP |
+| `updated_at`           | —                | ❌       | Highly volatile |
+| `pushed_at`            | —                | ❌       | Activity noise |
+| `size`                 | —                | ❌       | Low OSINT value |
+| `default_branch`       | —                | ❌       | Operational detail |
+| `clone_url`            | —                | ❌       | Non-OSINT |
+| `ssh_url`              | —                | ❌       | Non-OSINT |
+| `fork`                 | —                | ❌       | Context-specific, excluded for MVP |
+| `archived`             | —                | ❌       | Edge-case, low signal |
+| `disabled`             | —                | ❌       | Rare, non-actionable |
+| `permissions`          | —                | ❌       | Auth-dependent |
+| `hooks_url`            | —                | ❌       | Internal API URL |
+| `issues_url`           | —                | ❌       | Internal API URL |
+
+## Lógica de Normalização
+
+A normalização atual é implementada da seguinte forma:
+
+```bash
+parse_github_repos() {
+    jq '.[] | {
+        id,
+        name: .name,
+        full_name: .full_name,
+        description,
+        url: .html_url,
+        stars: .stargazers_count,
+        forks: .forks_count,
+        language
+    }'
+}
+````
+
+Cada repositório é emitido como um **objeto normalizado único**.
+
+## Contrato de Saída
+
+A saída normalizada está em conformidade com:
+
+```
+schemas/github_user_repos.json
+```
+
+Este esquema é a **definição oficial** da saída do repositório GitHub
+dentro do UnauthScout.
+
+## Justificativa
+
+A inclusão de campos segue estes princípios:
+
+* Os campos devem estar sempre presentes
+* Os campos devem ser relevantes para OSINT (Inteligência de Fontes Abertas)
+* Os campos devem suportar paridade entre provedores
+* Os campos não devem exigir autenticação
+* Os campos devem ser automatizáveis ​​e estáveis
+
+Todos os outros campos são intencionalmente excluídos para reduzir ruído, evitar desvios na API
+e preservar a estabilidade do contrato a longo prazo.
+
+## Notas sobre a Evolução
+
+* Metadados adicionais (ex.: licença, tópicos) poderão ser adicionados em versões futuras.
+* Os cronogramas de atividade do repositório foram intencionalmente excluídos do escopo do MVP.
+* Campos exclusivos para usuários autenticados exigirão um contrato e um esquema separados.
+* Alterações que quebrem a compatibilidade serão documentadas explicitamente.
+
+## Resumo
+
+Este mapeamento garante que o UnauthScout emita uma **representação limpa, minimalista e previsível** dos repositórios públicos do GitHub, adequada para fluxos de trabalho OSINT,
+pipelines de automação e expansão futura de provedores.

--- a/docs/pt/content/api_maps/gitlab-repo-map.md
+++ b/docs/pt/content/api_maps/gitlab-repo-map.md
@@ -1,0 +1,110 @@
+# Mapeamento de Campos da API de Projetos do GitLab
+
+Este documento descreve como os campos da **resposta da API de Projetos do GitLab não autenticada**
+são mapeados e normalizados pelo UnauthScout.
+
+Ele serve como referência para:
+- Entender quais campos brutos são usados
+- Validar o alinhamento do esquema
+- Auditar as decisões de normalização
+
+## Endpoint
+
+```
+
+GET [https://gitlab.com/api/v4/users/{username}/projects](https://gitlab.com/api/v4/users/{username}/projects)
+
+```
+
+- Autenticação: ❌ Não obrigatória
+- Escopo: Somente projetos públicos
+- Filtros: `visibility=public`
+- Paginação: `per_page=100`
+
+## Visão Geral da Resposta Bruta
+
+A API de Projetos do GitLab retorna um **array de objetos de projeto**, cada um contendo
+metadados, URLs internas, permissões e campos de configuração específicos da plataforma.
+
+O UnauthScout seleciona intencionalmente um **subconjunto mínimo** de metadados de projeto estáveis ​​e relevantes para OSINT,
+adequados para normalização entre provedores.
+
+## Mapeamento de Campos
+
+| Raw Field                | Normalized Field | Included | Notes |
+|--------------------------|------------------|----------|-------|
+| `id`                     | `id`             | ✅       | Stable unique project identifier |
+| `name`                   | `name`           | ✅       | Project name |
+| `path_with_namespace`    | `path`           | ✅       | Fully qualified project path |
+| `description`            | `description`    | ✅       | Nullable, contextual |
+| `web_url`                | `url`            | ✅       | Public project URL |
+| `star_count`             | `stars`          | ✅       | Popularity signal |
+| `forks_count`            | `forks`          | ✅       | Reuse and activity signal |
+| `visibility`             | —                | ❌       | Filtered at request time |
+| `namespace`              | —                | ❌       | Redundant with path |
+| `owner`                  | —                | ❌       | Not always present |
+| `default_branch`         | —                | ❌       | Operational detail |
+| `created_at`             | —                | ❌       | Not required for MVP |
+| `last_activity_at`       | —                | ❌       | Volatile |
+| `archived`               | —                | ❌       | Edge-case, low signal |
+| `topics`                 | —                | ❌       | Not consistently populated |
+| `readme_url`             | —                | ❌       | Secondary resource |
+| `http_url_to_repo`       | —                | ❌       | Non-OSINT |
+| `ssh_url_to_repo`        | —                | ❌       | Non-OSINT |
+| `permissions`            | —                | ❌       | Auth-dependent |
+| `_links`                 | —                | ❌       | Internal API URLs |
+
+## Lógica de Normalização
+
+A normalização atual é implementada da seguinte forma:
+
+```bash
+parse_gitlab_repos() {
+    jq '.[] | {
+        id,
+        name: .name,
+        path: .path_with_namespace,
+        description,
+        url: .web_url,
+        stars: .star_count,
+        forks: .forks_count
+    }'
+}
+````
+
+Cada projeto é emitido como um **objeto normalizado único**.
+
+## Contrato de Saída
+
+A saída normalizada está em conformidade com:
+
+```
+schemas/gitlab_user_repos.json
+```
+
+Este esquema é a **definição oficial** da saída de projetos do GitLab
+dentro do UnauthScout.
+
+## Justificativa
+
+A inclusão de campos segue estes princípios:
+
+* Os campos devem estar sempre presentes
+* Os campos devem ser relevantes para OSINT (Inteligência de Fontes Abertas)
+* Os campos devem suportar paridade entre provedores
+* Os campos não devem exigir autenticação
+* Os campos devem ser estáveis ​​entre as versões do GitLab
+
+Todos os outros campos são intencionalmente excluídos para reduzir ruído, evitar acoplamento específico da plataforma e preservar a estabilidade do contrato a longo prazo.
+
+## Notas sobre a Evolução
+
+* Metadados adicionais (por exemplo, tópicos, licença) poderão ser adicionados em versões futuras.
+* Projetos pertencentes a grupos poderão receber tratamento estendido em versões futuras.
+* Campos exclusivos para usuários autenticados exigirão um contrato e um esquema separados.
+* Alterações que quebrem a compatibilidade serão documentadas explicitamente.
+
+## Resumo
+
+Este mapeamento garante que o UnauthScout emita uma **representação limpa, minimalista e previsível** de projetos públicos do GitLab, adequada para fluxos de trabalho de OSINT,
+pipelines de automação e análises independentes de provedor.

--- a/docs/pt/content/api_maps/gitlab-user-map.md
+++ b/docs/pt/content/api_maps/gitlab-user-map.md
@@ -14,7 +14,7 @@ Ele fornece uma referência clara para:
 
 GET [https://gitlab.com/api/v4/users?username={username}](https://gitlab.com/api/v4/users?username={username})
 
-````
+```
 
 - Autenticação: ❌ Não é necessária
 - Escopo: Somente dados públicos do usuário

--- a/docs/pt/content/home.md
+++ b/docs/pt/content/home.md
@@ -17,14 +17,23 @@ Esta wiki segue os princípios **DRY (Don't Repeat Yourself - Não se Repita)**:
 
 ## 📢 Novidades
 
-### Versão mais recente: [v0.1.0](https://github.com/rmottanet/unauthscout/releases/tag/v0.1.0)
+### Versão mais recente: [v0.2.0](https://github.com/rmottanet/unauthscout/releases/tag/v0.2.0)
+- **Enumeração de repositórios** – Listagem de repositórios de usuários para GitHub e GitLab
+- Documentação expandida de mapeamento de campos da API
+- Atualizações de documentação multilíngue (EN/PT)
+- CLI aprimorada com suporte à flag `--repos`
+
+### Versão anterior: [v0.1.0](https://github.com/rmottanet/unauthscout/releases/tag/v0.1.0)
 - Enumeração de usuários do GitLab
 - Saída JSON normalizada via esquemas
-- Interface de linha de comando básica
-- Arquitetura baseada em provedores
+- Interface CLI básica
+- Base para arquitetura baseada em provedores
 
-### Em desenvolvimento (v0.2.0)
-- **Enumeração de repositórios** - Listagem de repositórios de usuários para ambos os provedores
+### Atualmente em desenvolvimento (v0.3.0)
+- **Normalização e inteligência resumida** – Transformação de dados brutos do provedor em insights de reconhecimento unificados
+- Comparação de dados aprimorada entre plataformas
+- Resumo inteligente de pegadas de usuários e repositórios
+- Base para correlação e relatórios entre fornecedores
 
 ## 📌 Observações importantes
 

--- a/docs/pt/content/home/osint-flow.md
+++ b/docs/pt/content/home/osint-flow.md
@@ -24,140 +24,215 @@ O objetivo não é a exaustão de dados, mas a **extração de sinais**:
 - Os contratos devem refletir a **realidade observável**, não a capacidade teórica da API
 
 
-## Fluxo de alto nível
+## Fluxo Geral
 
 ```txt
-
-Alvo
+Destino
 ↓
-Seleção do provedor
+Seleção do Provedor
 ↓
-Solicitação de API não autenticada
+Requisição de API Não Autenticada
 ↓
-Resposta bruta
+Resposta Bruta
 ↓
-Normalização (esquema)
+Normalização (Esquema)
 ↓
-Saída estruturada
+Saída Estruturada
+````
 
-```
+Cada etapa tem uma **única responsabilidade** e um limite claramente definido.
 
-Cada etapa tem uma **responsabilidade única** e um limite claramente definido.
+## Detalhamento Passo a Passo
 
+### 1. Identificação do Destino
 
-## Detalhamento passo a passo
-
-### 1. Identificação do alvo
-
-O usuário fornece um identificador de alvo (por exemplo, nome de usuário).
+O usuário fornece um identificador de destino (por exemplo, nome de usuário).
 
 O UnauthScout não:
-- Adivinha identidades
-- Estabelece correlações entre plataformas
-- Realiza enriquecimento nesta etapa
 
-O alvo é tratado como um identificador opaco passado para o provedor.
+* Tenta adivinhar identidades
+* Correlaciona entre plataformas
+* Realiza enriquecimento nesta etapa
 
+O destino é tratado como um identificador opaco passado para o provedor.
 
-### 2. Seleção do provedor
+### 2. Seleção do Provedor
 
 A CLI determina qual módulo do provedor invocar (por exemplo, GitHub, GitLab).
 
 Responsabilidades:
-- Roteamento
-- Tratamento de sinalizadores (`--raw`, modos de saída futuros)
-- Propagação de erros
+
+* Roteamento
+* Manipulação de flags (`--raw`, `--repos`)
+* Propagação de erros
 
 O ponto de entrada **não implementa lógica de reconhecimento**.
 
+### 3. Requisição de API não autenticada
 
-### 3. Solicitação de API não autenticada
+Cada módulo provedor realiza:
 
-Cada módulo do provedor executa:
-- Uma solicitação direta à API pública
-- Sem autenticação
-- Sem novas tentativas ou evasão de limite de taxa
+* Uma requisição direta à API pública
+* Sem autenticação
+* Sem novas tentativas ou evasão de limite de taxa
 
 Isso garante:
-- Uso ético
-- Reprodutibilidade
-- Limites de confiança claros
 
+* Uso ético
+* Reprodutibilidade
+* Limites de confiança claros
 
-### 4. Tratamento de resposta bruta
+### 4. Manipulação de Resposta Bruta
 
 A resposta bruta da API representa a **verdade fundamental**.
 
-O UnauthScout oferece suporte a um modo `--raw` para:
-- Inspecionar campos disponíveis
-- Validar suposições
-- Auxiliar na evolução do esquema
+O UnauthScout suporta um modo `--raw` para:
+
+* Inspecionar campos disponíveis
+* Validar suposições
+* Auxiliar na evolução do esquema
 
 A saída bruta destina-se à **análise e desenvolvimento**, não à automação.
 
-
 ### 5. Normalização
 
-A normalização transforma respostas brutas em um **contrato estável e mínimo**.
+A normalização transforma as respostas brutas em um **contrato mínimo e estável**.
 
 Princípios:
-- Incluir apenas campos que estejam consistentemente disponíveis
-- Evitar campos voláteis ou internos do provedor
-- Preferir identificadores e atributos públicos
 
-A normalização é implementada por meio de funções de analisador dedicadas e esquemas documentados
-em `schemas/`.
+* Incluir apenas campos que estejam sempre disponíveis
+* Evitar campos voláteis ou internos ao provedor
+* Dar preferência a identificadores e atributos públicos
 
+A normalização é implementada por meio de funções de análise sintática dedicadas e esquemas documentados em `schemas/`.
 
-### 6. Saída estruturada
+### 6. Saída Estruturada
 
 A saída final:
-- É determinística
-- Está em conformidade com um esquema documentado
-- É adequada para scripts, armazenamento e ferramentas downstream
 
-Essa saída é a **interface principal** do UnauthScout.
+* É determinística
+* Está em conformidade com um esquema documentado
+* É adequada para scripts, armazenamento e ferramentas subsequentes
 
+Esta saída é a **interface principal** do UnauthScout.
 
-## Porque os esquemas são importantes
+## Enumeração de Repositórios/Projetos
+
+A enumeração de repositórios (GitHub) e projetos (GitLab) é uma **extensão condicional**
+do fluxo OSINT principal, ativada explicitamente pela flag `--repos`.
+
+Esta fase segue o **mesmo modelo mental** do reconhecimento de perfil e
+não introduz uma nova classe de comportamento.
+
+### Condição de Acionamento
+
+A enumeração ocorre somente quando:
+
+* Um usuário/perfil válido é observado em um provedor
+* O usuário solicita explicitamente a listagem de repositórios (`--repos`)
+
+Isso evita:
+
+* Chamadas de API desnecessárias
+* Exaustão acidental do limite de requisições
+* Expansão implícita do escopo
+
+### Fluxo de Enumeração
+
+```txt
+Usuário Normalizado Identificado
+↓
+Requisição de Repositório/Projeto Público
+↓
+Resposta Bruta do Repositório
+↓
+Normalização do Repositório (Esquema)
+↓
+Saída Estruturada do Repositório
+```
+
+Cada repositório/projeto é tratado como uma **entidade observável independente**.
+
+### Princípios de Enumeração
+
+* Somente repositórios/projetos públicos são consultados
+* A enumeração é limitada por provedor
+* Nenhuma correlação entre provedores é realizada
+* Nenhuma busca recursiva (issues, commits, contribuidores)
+
+O objetivo é o **mapeamento superficial**, não uma inspeção profunda.
+
+### ### Normalização e Contratos
+
+Repositórios e projetos são normalizados em esquemas específicos do provedor, mas semanticamente alinhados:
+
+* `schemas/github_user_repos.json`
+* `schemas/gitlab_user_repos.json`
+
+A seleção de campos prioriza:
+
+* Identificadores
+* URLs públicas
+* Sinais de popularidade e atividade
+* Comparabilidade entre provedores
+
+Mapeamentos de campos detalhados estão documentados em:
+
+* `docs/api_maps/github_repo_map.md`
+* `docs/api_maps/gitlab_repo_map.md`
+
+### Características da Saída
+
+A saída da enumeração de repositórios:
+
+* É emitida como um fluxo de objetos normalizados
+* Preserva a ordem retornada pelo provedor
+* Pode ser consumida incrementalmente por ferramentas subsequentes
+
+A saída bruta (`--raw`) permanece disponível para inspeção e evolução do esquema.
+
+## Por que os Esquemas Importam
 
 Os esquemas servem como:
-- Um contrato entre fornecedores e consumidores
-- Documentação de comportamento observável
-- Uma proteção contra alterações silenciosas
 
-Os esquemas são autoritários.
+* Um contrato entre provedores e consumidores
+* Documentação do comportamento observável
+* Uma proteção contra alterações silenciosas que quebram a compatibilidade
+
+Os esquemas são autoritativos.
+
 O código se adapta aos esquemas, e não o contrário.
-
 
 ## O que este fluxo não abrange
 
 O UnauthScout exclui intencionalmente:
-- Reconhecimento autenticado
-- Tratamento de limite de taxa
-- Correlação entre plataformas
-- Análise comportamental
-- Rastreamento histórico
 
-Essas questões pertencem a sistemas de nível superior construídos *sobre* essa ferramenta.
+* Reconhecimento autenticado
+* Tratamento de limite de taxa
+* Correlação entre plataformas
+* Análise comportamental
+* Rastreamento histórico
+* Inspeção profunda do repositório (problemas, commits, CI)
 
+Essas preocupações pertencem a sistemas de nível superior construídos *sobre* esta ferramenta.
 
-## Estratégia de evolução
+## Estratégia de Evolução
 
 Extensões futuras seguem o mesmo fluxo:
-- Novo provedor → novo módulo
-- Novo endpoint → novo esquema
-- Novo formato de saída → questão no nível da CLI
 
-O fluxo OSINT permanece inalterado.
+* Novo provedor → novo módulo
+* Novo endpoint → novo esquema
+* Novo formato de saída → preocupação no nível da CLI
 
+O fluxo OSINT permanece estável.
 
 ## Resumo
 
 O UnauthScout foi projetado como um **primitivo**:
-- Pequeno
-- Previsível
-- Combinável
 
-Seu valor não reside no volume de dados coletados, mas na **clareza e
-confiabilidade** dos dados que emite.
+* Pequeno
+* Previsível
+* Componível
+
+Seu valor reside não no volume de dados coletados, mas na **clareza e
+confiabilidade** dos dados que ele emite.

--- a/docs/pt/content/home/setup.md
+++ b/docs/pt/content/home/setup.md
@@ -53,14 +53,54 @@ Comportamento esperado:
 * Sem solicitações de autenticação
 * Sem rastreamentos de pilha ou erros de shell
 
+## Enumeração de Repositórios/Projetos
+
+O UnauthScout pode, opcionalmente, enumerar **repositórios/projetos públicos** associados
+a um usuário por meio da flag `--repos`.
+
+Este recurso é **explicitamente ativado** e tem escopo definido por provedor.
+
+### Enumerar repositórios em ambos os provedores
+
+```bash
+unauthscout torvalds --repos
+```
+
+### Enumerar apenas repositórios do GitHub
+
+```bash
+unauthscout torvalds --github --repos
+```
+
+### Enumerar apenas projetos do GitLab
+
+```bash
+unauthscout dzaporozhets --gitlab --repos
+```
+
+### Combinar com o modo raw
+
+O modo raw pode ser usado para inspecionar as respostas originais da API:
+
+```bash
+unauthscout torvalds --repos --raw
+unauthscout torvalds --github --repos --raw
+```
+
+A saída raw é útil para:
+
+* Inspecionar campos recém-expostos
+* Validar o comportamento da API
+* Suportar a evolução do esquema
+
 ## Erros comuns e solução de problemas
 
-### Dependência ausente
+### Ausente Dependência
 
 **Erro**
 
 ```
-[ERROR] Missing required command: jq
+[ERRO] Comando necessário ausente: jq
 ```
 
 **Causa**
@@ -68,92 +108,101 @@ Comportamento esperado:
 * Uma ou mais ferramentas necessárias não estão instaladas ou não estão no PATH.
 
 **Solução**
+
 Instale a dependência ausente, por exemplo:
 
 ```bash
 sudo apt install jq
 ```
 
-### Falha na rede ou na API
+### Falha de rede ou API
 
 **Erro**
 
 ```
-[ERROR] Failed to fetch GitHub user data
+[ERRO] Falha ao buscar dados do usuário do GitHub
 ```
 
 ou
 
 ```
-[ERROR] Failed to fetch GitLab user data
+[ERRO] Falha ao buscar dados do usuário do GitLab
+```
+
+ou durante a enumeração de repositórios:
+
+```
+[ERRO] Falha ao buscar dados do repositório
 ```
 
 **Possíveis causas**
 
 * Problemas de conectividade de rede
 * Interrupção temporária da API
-* Limitação de taxa pelo provedor
+* Limitação de taxa do provedor
 
 **Solução**
 
 * Verifique o acesso à rede
-* Tente novamente a solicitação
-* Use `--raw` para inspecionar respostas parciais, se disponíveis
+* Tente novamente a solicitação após um atraso
+* Use `--raw` para inspecionar respostas parciais
 
 ### Falha na análise
 
 **Erro**
 
 ```
-[ERROR] Failed to parse API response
+[ERRO] Falha ao analisar a resposta da API
 ```
 
 **Causa**
 
-* Formato de resposta da API alterado
-* JSON vazio ou malformado inesperado
-* Incompatibilidade de ferramentas (versão `jq`)
+* Formato da resposta da API * JSON vazio ou malformado inesperado
+* Incompatibilidade de ferramentas (versão do `jq`)
 
-**Resolução**
+**Solução**
 
-* Execute novamente o comando com `--raw`
-* Compare a saída bruta com o mapeamento da API documentado
-* Valide o alinhamento do esquema
+* Execute o comando novamente com `--raw`
+* Compare a saída bruta com os mapeamentos da API documentada
+* Valide o alinhamento do esquema em `schemas/`
 
 ### Nenhum resultado retornado (GitLab)
 
 **Comportamento**
 
-* Saída vazia ou erro de análise
+* Saída vazia ou erro de análise durante a busca de perfil ou projeto
 
 **Causa**
 
-* O endpoint GitLab `/users?username=` retorna uma matriz vazia
+* O endpoint `/users?username=` do GitLab retorna um array vazio
 * O nome de usuário não existe ou é ambíguo
+* O usuário não possui projetos públicos
 
-**Resolução**
+**Solução**
 
 * Verifique o nome de usuário manualmente
 * Inspecione a saída bruta usando `--raw`
 
-## Depuração com o modo bruto
+## Depuração com o Modo Bruto
 
-O UnauthScout fornece um sinalizador `--raw` para ignorar a normalização:
+O UnauthScout fornece um parâmetro `--raw` para ignorar a normalização:
 
 ```bash
-unauthscout <username> --raw
-unauthscout <username> --raw -gh
+unauthscout <nome de usuário> --raw
+unauthscout <nome de usuário> --github --raw
+unauthscout <nome de usuário> --repos --raw
+
 ```
 
-Use o modo bruto para:
+Use o modo raw para:
 
 * Inspecionar campos recém-expostos
 * Validar o comportamento da API
 * Auxiliar na evolução do esquema
 
-O modo bruto destina-se à **análise e desenvolvimento**, não à automação.
+O modo raw destina-se à **análise e desenvolvimento**, não à automação.
 
-## Comportamento esperado de saída
+## Comportamento de saída esperado
 
 * A execução bem-sucedida retorna o código de saída `0`
 * Erros fatais encerram a execução com um código de saída diferente de zero
@@ -161,23 +210,24 @@ O modo bruto destina-se à **análise e desenvolvimento**, não à automação.
 
 ## Observações sobre limitação de taxa
 
-O UnauthScout não tenta contornar os limites de taxa.
+O UnauthScout não tenta burlar os limites de taxa.
 
-* As solicitações não autenticadas do GitHub têm taxa limitada
-* As solicitações não autenticadas do GitLab também podem ser limitadas
+* As requisições não autenticadas do GitHub têm limite de taxa.
+* As requisições não autenticadas do GitLab também podem ter sua taxa de requisições limitada.
 
 Para uso contínuo, considere:
 
-* Espaçar as solicitações
-* Adicionar suporte autenticado em uma versão futura
+* Espaçamento entre as requisições
+* Limitar o escopo do provedor (`--github` / `--gitlab`)
+* Adicionar suporte a autenticação em uma versão futura
 
 ## Resumo
 
 O UnauthScout foi projetado para falhar de forma rápida e visível.
 
-Se algo der errado:
+Se algo quebrar:
 
 1. Verifique as dependências
 2. Execute novamente com `--raw`
-3. Compare a saída bruta com os documentos de mapeamento da API
-4. Atualize os esquemas e analisadores de acordo
+3. Compare a saída bruta com a documentação de mapeamento da API
+4. Atualize os esquemas e analisadores sintáticos de acordo

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -32,25 +32,48 @@ is_empty() {
     [[ -z "$1" ]]
 }
 
+# --- Test Validation ---
+assert_not_empty() {
+    local data="$1"
+    local msg="$2"
+    if [[ -n "$data" && "$data" != "[]" && "$data" != "{}" ]]; then
+        log_success "Assertion Passed: $msg"
+        return 0
+    else
+        log_error "Assertion Failed: $msg"
+        return 1
+    fi
+}
+
 # --- Help Message ---
 show_help() {
     cat << EOF
 UnauthScout - OSINT reconnaissance for GitLab & GitHub (Unauthenticated)
 
 Usage:
-    $(basename "$0") <username>
-    $(basename "$0") [options]
+    $(basename "$0") [options] <username>
 
 Arguments:
     <username>      The target git username to scout.
 
-Options:
+Platform Filters:
+    -gh, --github   Search only on GitHub.
+    -gl, --gitlab   Search only on GitLab.
+    (If neither is specified, both platforms are searched)
+
+Search Options:
+    -r, --repos     List public repositories/projects for the user.
+    --raw           Output raw JSON instead of formatted results.
+
+General Options:
     -h, --help      Show this help message and exit.
 
 Examples:
-    ./bin/unauthscout gitlab-org
     ./bin/unauthscout rmottanet
+    ./bin/unauthscout --gitlab -r dzaporozhets
+    ./bin/unauthscout -gh --raw torvalds
 
 Note: This tool uses public endpoints and does not require API tokens.
+      Subject to rate limits (especially GitHub).
 EOF
 }

--- a/lib/github_api.sh
+++ b/lib/github_api.sh
@@ -20,3 +20,29 @@ parse_github_user() {
         following
     }'
 }
+
+
+# --- Repository Functions ---
+# SRP: Responsabilidade única de buscar os repositórios brutos
+get_github_repos_raw() {
+    local username=$1
+    # O endpoint padrão para listar repositórios de um usuário
+    # per_page=100 é o máximo permitido por página no GitHub
+    curl -sf -A "UnauthScout-Scanner" \
+        "${GITHUB_BASE_URL}/users/${username}/repos?type=public&per_page=100&sort=updated"
+}
+
+# SRP: Responsabilidade única de filtrar e formatar a saída para o Scout
+parse_github_repos() {
+    # Mapeamos os campos do GitHub para manter um padrão próximo ao do GitLab
+    jq '.[] | {
+        id,
+        name: .name,
+        full_name: .full_name,
+        description,
+        url: .html_url,
+        stars: .stargazers_count,
+        forks: .forks_count,
+        language
+    }'
+}

--- a/lib/gitlab_api.sh
+++ b/lib/gitlab_api.sh
@@ -17,3 +17,21 @@ parse_gitlab_user() {
         web_url
     }'
 }
+
+# --- Repository/Project Functions ---
+get_gitlab_repos_raw() {
+    local username=$1
+    curl -sf "${GITLAB_BASE_URL}/users/${username}/projects?visibility=public&per_page=100"
+}
+
+parse_gitlab_repos() {
+    jq '.[] | {
+        id,
+        name: .name,
+        path: .path_with_namespace,
+        description,
+        url: .web_url,
+        stars: .star_count,
+        forks: .forks_count
+    }'
+}

--- a/schemas/github_user_repos.json
+++ b/schemas/github_user_repos.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GitHubUserRepository",
+  "description": "Normalized public repository representation from GitHub user enumeration",
+  "type": "object",
+  "required": [
+    "id",
+    "name",
+    "full_name",
+    "url",
+    "stars",
+    "forks"
+  ],
+  "properties": {
+    "id": {
+      "type": "integer",
+      "description": "Unique repository ID assigned by GitHub"
+    },
+    "name": {
+      "type": "string",
+      "description": "Repository name"
+    },
+    "full_name": {
+      "type": "string",
+      "description": "Fully qualified repository name (owner/name)"
+    },
+    "description": {
+      "type": ["string", "null"],
+      "description": "Repository description"
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Public HTML URL of the repository"
+    },
+    "stars": {
+      "type": "integer",
+      "description": "Number of stargazers"
+    },
+    "forks": {
+      "type": "integer",
+      "description": "Number of forks"
+    },
+    "language": {
+      "type": ["string", "null"],
+      "description": "Primary programming language"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/gitlab_user_repos.json
+++ b/schemas/gitlab_user_repos.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GitLabUserProject",
+  "description": "Normalized public project representation from GitLab user enumeration",
+  "type": "object",
+  "required": [
+    "id",
+    "name",
+    "path",
+    "url",
+    "stars",
+    "forks"
+  ],
+  "properties": {
+    "id": {
+      "type": "integer",
+      "description": "Unique project ID assigned by GitLab"
+    },
+    "name": {
+      "type": "string",
+      "description": "Project name"
+    },
+    "path": {
+      "type": "string",
+      "description": "Project path with namespace (group/name or user/name)"
+    },
+    "description": {
+      "type": ["string", "null"],
+      "description": "Project description"
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Public web URL of the project"
+    },
+    "stars": {
+      "type": "integer",
+      "description": "Number of stars"
+    },
+    "forks": {
+      "type": "integer",
+      "description": "Number of forks"
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/test_github_api.sh
+++ b/tests/test_github_api.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# tests/test_github_api.sh
+# Responsabilidade: Validar as funções de integração com a API do GitHub (OSINT)
+
+BASE_DIR=$(dirname "$(readlink -f "$0")")/..
+source "${BASE_DIR}/lib/core.sh"
+source "${BASE_DIR}/lib/github_api.sh"
+
+# Alvo de teste (usando 'google' ou 'github' como alvos públicos estáveis)
+TEST_TARGET="torvalds"
+
+# --- Testes de Perfil de Usuário ---
+
+test_get_user() {
+    log_info "Testing: get_github_user_raw"
+    local raw
+    raw=$(get_github_user_raw "$TEST_TARGET")
+    assert_not_empty "$raw" "Raw GitHub user data should not be empty"
+}
+
+test_parse_user() {
+    log_info "Testing: parse_github_user"
+    local raw
+    raw=$(get_github_user_raw "$TEST_TARGET")
+    
+    local parsed
+    parsed=$(echo "$raw" | parse_github_user)
+    
+    # No GitHub, o campo é 'login' (conforme seu github_api.sh)
+    local login
+    login=$(echo "$parsed" | jq -r '.login')
+    
+    [[ "$login" == "$TEST_TARGET" ]]
+    assert_not_empty "$login" "Parsed login should match $TEST_TARGET"
+}
+
+# --- Testes de Repositórios ---
+
+test_get_repos() {
+    log_info "Testing: get_github_repos_raw"
+    local raw
+    raw=$(get_github_repos_raw "$TEST_TARGET")
+    
+    # O GitHub retorna um array para a lista de repositórios
+    if echo "$raw" | jq -e 'type == "array"' > /dev/null; then
+        assert_not_empty "$raw" "Should return a JSON array of repositories"
+    else
+        log_error "Assertion Failed: Output is not a JSON array"
+        return 1
+    fi
+}
+
+test_parse_repos() {
+    log_info "Testing: parse_github_repos"
+    local raw
+    raw=$(get_github_repos_raw "$TEST_TARGET")
+    local parsed
+    parsed=$(echo "$raw" | parse_github_repos)
+    
+    # Valida o mapeamento de campos (GitHub original 'stargazers_count' -> nosso 'stars')
+    local first_item_stars
+    first_item_stars=$(echo "$parsed" | jq -r -s '.[0].stars')
+    
+    # Verifica se o campo 'stars' existe no objeto parseado (mesmo que seja 0)
+    if [[ "$first_item_stars" =~ ^[0-9]+$ ]]; then
+        log_success "Assertion Passed: Field 'stars' is present and numeric"
+    else
+        log_error "Assertion Failed: Field 'stars' missing or not numeric"
+        return 1
+    fi
+    
+    # Valida o mapeamento de URL
+    local first_url
+    first_url=$(echo "$parsed" | jq -r -s '.[0].url')
+    assert_not_empty "$first_url" "Parsed output should have html_url mapped to 'url'"
+}
+
+# --- Runner ---
+run_all_github_tests() {
+    echo -e "\n${CLR_INFO}>>> Starting GitHub API Integration Tests${CLR_RESET}"
+    echo "------------------------------------------------------------"
+    
+    # Nota: Cuidado com o Rate Limit do GitHub (60 req/hora para IP não autenticado)
+    test_get_user
+    test_parse_user    
+    test_get_repos
+    test_parse_repos
+
+    echo "------------------------------------------------------------"
+    log_success "All GitHub tests completed."
+}
+
+# Execução condicional
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    run_all_github_tests
+fi

--- a/tests/test_gitlab_api.sh
+++ b/tests/test_gitlab_api.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# tests/test_gitlab_api.sh
+# Responsabilidade: Validar as funções de integração com a API do GitLab
+
+BASE_DIR=$(dirname "$(readlink -f "$0")")/..
+source "${BASE_DIR}/lib/core.sh"
+source "${BASE_DIR}/lib/gitlab_api.sh"
+
+# Alvo de teste (usuário real para validação de integração)
+TEST_TARGET="dzaporozhets"
+
+# --- Testes de Perfil de Usuário ---
+
+test_get_user() {
+    log_info "Testing: get_gitlab_user_raw"
+    local raw
+    raw=$(get_gitlab_user_raw "$TEST_TARGET")
+    assert_not_empty "$raw" "Raw user data should not be empty"
+}
+
+test_parse_user() {
+    log_info "Testing: parse_gitlab_user"
+    local raw
+    raw=$(get_gitlab_user_raw "$TEST_TARGET")
+    
+    local parsed
+    parsed=$(echo "$raw" | parse_gitlab_user)
+    
+    local username
+    username=$(echo "$parsed" | jq -r '.username')
+    
+    # Valida se o parser extraiu o username correto
+    [[ "$username" == "$TEST_TARGET" ]]
+    assert_not_empty "$username" "Parsed username should match $TEST_TARGET"
+}
+
+# --- Testes de Repositórios/Projetos ---
+
+test_get_repos() {
+    log_info "Testing: get_gitlab_repos_raw"
+    local raw
+    raw=$(get_gitlab_repos_raw "$TEST_TARGET")
+    
+    # Validação estrutural: O endpoint de projetos DEVE retornar um array
+    if echo "$raw" | jq -e 'type == "array"' > /dev/null; then
+        assert_not_empty "$raw" "Should return a JSON array of projects"
+    else
+        log_error "Assertion Failed: Output is not a JSON array"
+        return 1
+    fi
+}
+
+test_parse_repos() {
+    log_info "Testing: parse_gitlab_repos"
+    local raw
+    raw=$(get_gitlab_repos_raw "$TEST_TARGET")
+    
+    local parsed
+    parsed=$(echo "$raw" | parse_gitlab_repos)
+    
+    # Verifica presença de campos mapeados no primeiro item da lista
+    local first_item_name
+    first_item_name=$(echo "$parsed" | jq -r -s '.[0].name')
+    assert_not_empty "$first_item_name" "Parsed output should contain project names (found: $first_item_name)"
+    
+    # Verifica se o mapeamento 'path_with_namespace' -> 'path' funcionou
+    local first_item_path
+    first_item_path=$(echo "$parsed" | jq -r -s '.[0].path')
+    assert_not_empty "$first_item_path" "Parsed output should have path_with_namespace mapped to 'path'"
+}
+
+# --- Runner ---
+# Orquestra a execução de todos os testes deste módulo
+run_all_gitlab_tests() {
+    echo -e "\n${CLR_INFO}>>> Starting GitLab API Integration Tests${CLR_RESET}"
+    echo "------------------------------------------------------------"
+    
+    test_get_user
+    test_parse_user    
+    test_get_repos
+    test_parse_repos
+
+    echo "------------------------------------------------------------"
+    log_success "All GitLab tests completed."
+}
+
+# Execução condicional: só roda se o script for chamado diretamente
+# Isso permite que as funções sejam importadas por outros scripts sem rodar o runner
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    run_all_gitlab_tests
+fi


### PR DESCRIPTION
## Summary

This PR introduces **public repository / project enumeration** as a first-class,
opt-in capability in UnauthScout.

The feature extends the existing unauthenticated OSINT flow to include **asset
surface discovery**, while preserving the tool’s core principles:

* No authentication
* Explicit scope control
* Stable, documented output contracts
* Provider-agnostic normalization

The implementation is complete, tested, and fully documented.

---

## What’s Included

###  Features

* Public repository enumeration for **GitHub**
* Public project enumeration for **GitLab**
* New CLI flag: `--repos`
* Provider-scoped execution (`--github`, `--gitlab`)
* Raw inspection support via `--raw`

###  Normalization & Contracts

* Added normalized schemas:

  * `schemas/github_user_repos.json`
  * `schemas/gitlab_user_repos.json`
* Stable, minimal, OSINT-focused repository contracts
* Cross-provider semantic alignment (stars, forks, URLs, identifiers)

###  Tests

* Integration tests covering:

  * User profile fetch
  * Repository/project enumeration
  * Parsing and field mapping validation
* Tests validate observable behavior against live public APIs

### Documentation

* API field mappings:

  * GitHub repositories
  * GitLab projects
* Extended OSINT flow to include asset enumeration
* Updated setup guide with new flags, examples, and troubleshooting
* Documentation explicitly references upstream provider APIs as raw sources

---

## OSINT Flow Impact

Repository / project enumeration is implemented as a **conditional extension**
of the existing reconnaissance flow:

* Triggered only via `--repos`
* Executed only after a valid user is observed
* No recursive traversal or deep inspection
* No implicit scope expansion

The core OSINT model remains unchanged.

---

## Design Decisions

* Enumeration is **explicit**, not implicit
* Raw provider responses remain inspectable
* Schemas are authoritative; code conforms to contracts
* No rate-limit evasion or authentication logic introduced
* No cross-provider correlation at this stage

These decisions preserve predictability, ethics, and composability.

---

## Backward Compatibility

* Existing user-only reconnaissance remains unchanged
* No breaking changes to existing schemas or CLI usage
* New functionality is strictly opt-in

---

## Versioning

This PR completes the functional scope for **v0.2.0**.

A separate PR will introduce:

* `CHANGELOG.md`
* Version tagging
* Release notes

This keeps `main` as the production truth line.

---

## How to Test

```bash
# User profile only
unauthscout torvalds

# Enumerate repositories on both providers
unauthscout torvalds --repos

# GitHub only
unauthscout torvalds --github --repos

# Inspect raw responses
unauthscout torvalds --repos --raw
```

Run integration tests:

```bash
bash tests/test_github_api.sh
bash tests/test_gitlab_api.sh
```

---

## Final Notes

This PR elevates UnauthScout from **identity discovery** to **asset surface
enumeration**, while maintaining a strict, documented, and testable OSINT
primitive.

The system remains small, predictable, and extensible.
