### PR TITLE
CHANGELOG for v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@ The format follows **Keep a Changelog** and adheres to **Semantic Versioning**.
 
 ---
 
+## [v0.2.0] — Repository Enumeration Release
+
+### Added
+- **Public repository enumeration for GitHub** – Unauthenticated repository listing via `/users/{username}/repos`
+- **Public project enumeration for GitLab** – Unauthenticated project listing via `/users/{username}/projects`
+- **New CLI flag `--repos`** – Opt-in repository/project enumeration after successful user reconnaissance
+- **Repository output schemas** – Normalized contracts for cross-provider consistency:
+  - `schemas/github_user_repos.json`
+  - `schemas/gitlab_user_repos.json`
+- **Enhanced provider orchestration** – Combined user and repository flows with explicit scope control
+- **Integration test suites** – Live API validation for repository endpoints across both providers
+
+### Enhanced
+- **CLI interface** – Extended with repository-specific execution paths while maintaining backward compatibility
+- **OSINT flow documentation** – Updated mental model to include asset surface discovery phase
+- **API field mapping documentation** – Comprehensive raw-to-normalized mappings for repository responses
+- **Setup and usage guides** – Examples and troubleshooting for new enumeration capabilities
+
+### Design Notes
+- Repository enumeration is **explicit and opt-in** (`--repos` flag required)
+- No authentication logic or rate-limit evasion mechanisms introduced
+- Raw provider responses remain inspectable via `--raw` flag
+- Schemas act as authoritative output contracts; code conforms to contracts
+- Strict separation between user reconnaissance and asset enumeration phases
+- No implicit scope expansion or recursive traversal
+
+### Documentation
+- Extended API field mappings for GitHub repositories and GitLab projects
+- Updated OSINT flow to include conditional repository enumeration step
+- Enhanced setup guide with new flag usage, examples, and edge cases
+- All documentation references upstream provider APIs as authoritative sources
+
+### Known Limitations
+- Subject to unauthenticated API rate limits (stricter for repository endpoints)
+- Limited to publicly accessible repositories/projects
+- No cross-provider correlation or deduplication logic
+- No repository content analysis or metadata enrichment
+- Pagination not implemented (first page only)
+
+---
+
 ## [v0.1.0] — Initial MVP Release
 
 ### Added
@@ -38,4 +79,5 @@ The format follows **Keep a Changelog** and adheres to **Semantic Versioning**.
 
 ---
 
+[v0.2.0]: https://github.com/rmottanet/unauthscout/releases/tag/v0.2.0
 [v0.1.0]: https://github.com/rmottanet/unauthscout/releases/tag/v0.1.0


### PR DESCRIPTION
### Summary
Add `CHANGELOG.md` documentation for the `v0.2.0` release, which introduces public repository/project enumeration as a first-class, opt-in capability in UnauthScout.

This PR establishes a clear release history baseline for the repository enumeration milestone and maintains semantic versioning compliance for future iterations.

---

### Changes
- Updated `CHANGELOG.md` with complete `v0.2.0` release documentation
- Documented new features, enhanced capabilities, and design decisions
- Maintained backward compatibility section and known limitations
- Added release link reference for `v0.2.0`

---

### Scope
- Documentation only
- No code or behavioral changes
- Maintains existing `v0.1.0` history as previous release section

---

### Release Readiness
This PR is intended to be merged **after** the `dev → main` promotion of repository enumeration features and **before** tagging `v0.2.0`.

---

### Design Consistency
- Follows **Keep a Changelog** format and **Semantic Versioning**
- Maintains project's strict OSINT primitive philosophy in documentation
- Reflects explicit, opt-in design decisions for new functionality
- Preserves clear separation between user reconnaissance and asset enumeration phases